### PR TITLE
Fixed wrong default argument of `config`.

### DIFF
--- a/doorman/main.py
+++ b/doorman/main.py
@@ -25,7 +25,7 @@ group.add_argument('-u', '--unsecret', action="store_false", dest="status", help
 group.add_argument('-s', '--secret', action="store_true", dest="status", help='Hide all secret things')
 parser.add_argument('-v', '--verbose', action="store_true", dest="verbose", help='Show all messages')
 parser.add_argument('-c', '--config', action="store", dest="config_file",
-                    default=DEFAULT_CONFIG_PATH, help='Config file')
+                    default=DEFAULT_CONFIG_FILE, help='Config file')
 args = parser.parse_args()
 
 


### PR DESCRIPTION
It caused `IOError [Errno 21] Is a direcotory`
when user runs it without -c option.

Here's full traceback:

```
Traceback (most recent call last):
  File "/home/hirokiky/dev/doorman/env/bin/doorman", line 9, in <module>
    load_entry_point('doorman==0.4.0', 'console_scripts', 'doorman')()
  File "/home/hirokiky/dev/doorman/doorman/doorman/main.py", line 44, in main
    doorman = Doorman(args.status, os.path.abspath(args.config_file))
  File "/home/hirokiky/dev/doorman/doorman/doorman/doorman.py", line 64, in __init__
    self.__config = DoormanConfig(config_file).parseYAML()
  File "/home/hirokiky/dev/doorman/doorman/doorman/doorman.py", line 35, in parseYAML
    with open(self.__config_file, "r") as f:
IOError: [Errno 21] Is a directory: '/home/hirokiky/.config/doorman'
```

I know it doesnt contain any additions of tests. but I couldn't find good place to write (tests for command line options or some).
